### PR TITLE
fix: build graph in publications page

### DIFF
--- a/dashboard/pages/05_📚_publicaciones.py
+++ b/dashboard/pages/05_📚_publicaciones.py
@@ -4,7 +4,7 @@ import pandas as pd
 import altair
 
 from models import JournalPaper, Person, Journal, ConferencePresentation, Book, BookChapter
-
+from modules.graph import build_publications_graph
 
 st.set_page_config(
     page_title="MatCom Dashboard - Publicaciones", page_icon="📚", layout="wide"


### PR DESCRIPTION
### Se arregla el error de importación de `build_publications_graph` en la páguina de publicaciones

![1668922250 screensht](https://user-images.githubusercontent.com/93418478/202887304-5b025b5d-1a5b-4d59-b7ef-54fcbb9f11e8.png)
